### PR TITLE
Added Prop to enable nested scroll in Android - defaults to false

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,6 +141,7 @@ function SelectBox({
     searchIconColor = Colors.primary,
     toggleIconColor = Colors.primary,
     searchInputProps,
+    nestedScroll,
     multiSelectInputFieldProps,
   } = props
   const filteredSuggestions = useMemo(
@@ -239,6 +240,7 @@ function SelectBox({
             ListEmptyComponent={optionListEmpty}
             style={kOptionsHeight}
             ListHeaderComponent={HeaderComponent()}
+            nestedScrollEnabled={nestedScroll}
           />
         )}
       </View>


### PR DESCRIPTION
This PR address the inability to scroll in Android if your element is nested inside of a scrollview.

So say you have a form with a scrollview. The code below wouldn't work because Nested Scrolling is not enabled by default. So it iOS user would have no issue but Android users cannot the options list because the parent Scroll view is overriding responding to the child scroll events.
`
<ScrollView style={styles.container} nestedScrollEnabled={true}>
  <SelectBox
      label="Select country"
      options={countryList()}
      value={values.spm_country}
      onChange={(val) => setFieldValue('spm_country', val)}
      hideInputFilter={false}
      arrowIconColor={'#0055A4'}
      searchIconColor={'#0055A4'}
      toggleIconColor={'#0055A4'}
      nestedScroll={true}
    />
`
To fix this, I added a nestedScroll prop that if set to true, allows nested scrolling for persons who need that in their application. Quite frankly, I don't imagine a scenario that you wouldn't but the prop allows one to determine what scenario best fits their needs.