### PR TITLE
Change how Toggle "checked" prop is determined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ function SelectBox({
             </TouchableOpacity>
             <Toggle
               iconColor={toggleIconColor}
-              checked={selectedValues.indexOf(item) > -1}
+              checked={selectedValues.some(i => item.id === i.id)}
               onTouch={onPressMultiItem()}
             />
           </>


### PR DESCRIPTION
This PR is to resolve an issue I'm having, and that I believe was reported in #24, where the 'addCircle' icon doesn't change to a 'deleteCircle' when the item is selected.

The "checked" prop that is passed to the Toggle component is calculated using 'indexOf', which means that the object references of the item in "options" and the item in "selectedValues" must match in order for the icon to change to the deleteCircle. It seems that even the sample code may not ensure that the references are the same, as the issue exists for me using that code exactly.

I believe that a better solution is to check if any object with a matching id property exists using the 'some' method. As the id is expected to be unique, this ensures that object references do not need to match.