### PR TITLE
Add listOptionProps to props

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ export default App
 | selectedItemStyle         | style object |                                                                                                                                                        Default style |
 searchInputProps         | object |                                                                                                                                                        Default props |
 multiSelectInputFieldProps         | object |                                                                                                                                                        Default props |
+| listOptionProps          | object |      Default props |
 | arrowIconColor         | color string |                                                                                                                                                        Default primary color |
 | searchIconColor         | color string |                                                                                                                                                        Default primary color |
 | toggleIconColor         | color string |                                                                                                                                                        Default primary color |

--- a/lib/README.md
+++ b/lib/README.md
@@ -150,6 +150,7 @@ export default App
 | selectedItemStyle         | style object |                                                                                                                                                        Default style |
 searchInputProps         | object |                                                                                                                                                        Default props |
 multiSelectInputFieldProps         | object |                                                                                                                                                        Default props |
+| listOptionProps          | object |      Default props |
 | arrowIconColor         | color string |                                                                                                                                                        Default primary color |
 | searchIconColor         | color string |                                                                                                                                                        Default primary color |
 | toggleIconColor         | color string |                                                                                                                                                        Default primary color |

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,6 +142,7 @@ function SelectBox({
     toggleIconColor = Colors.primary,
     searchInputProps,
     multiSelectInputFieldProps,
+    listOptionProps = {},
   } = props
   const filteredSuggestions = useMemo(
     () => options.filter((suggestion) => suggestion.item.toLowerCase().indexOf(inputValue.toLowerCase()) > -1),
@@ -237,8 +238,9 @@ function SelectBox({
             maxToRenderPerBatch={20}
             windowSize={10}
             ListEmptyComponent={optionListEmpty}
-            style={kOptionsHeight}
+            style={[kOptionsHeight, listOptionProps.style]}
             ListHeaderComponent={HeaderComponent()}
+            {...listOptionProps}
           />
         )}
       </View>


### PR DESCRIPTION
Add `listOptionProps` to props to make it possible to override option list `FlatList` properties:

**Example Usage**

```jsx
<SelectBox
  label="Select multiple"
  options={K_OPTIONS}
  selectedValues={selectedTeams}
  onMultiSelect={onMultiChange()}
  onTapClose={onMultiChange()}
  isMulti
  listOptionProps={{ style: { maxHeight: 360 }, nestedScrollEnabled: true }}
/>
```

`style` property will be merged to `kOptionsHeight`

Also will solve the problem of nestedScrolling in Android and cover PR https://github.com/sauzy34/react-native-multi-selectbox/pull/34