### PR TITLE
Bottom border color prop & option of no remove items selected

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ function SelectBox({
   multiListEmptyLabelStyle,
   listEmptyLabelStyle,
   selectedItemStyle,
+  removeItemsSelected,
   listEmptyText = 'No results found',
   ...props
 }) {
@@ -112,14 +113,18 @@ function SelectBox({
     const kMultiOptionsLabelStyle = {
       fontSize: 10,
       color: '#fff',
+      padding: 4,
+      marginRight: 5,
       ...multiOptionsLabelStyle,
     }
+
     return (
       <View style={kMultiOptionContainerStyle}>
         <Text style={kMultiOptionsLabelStyle}>{label.item}</Text>
-        <TouchableOpacity style={{ marginLeft: 15 }} hitSlop={hitSlop} onPress={onPressItem()}>
-          <Icon name="closeCircle" fill="#fff" width={21} height={21} />
-        </TouchableOpacity>
+        { removeItemsSelected ?
+          <TouchableOpacity hitSlop={hitSlop} onPress={onPressItem()}>
+            <Icon name="closeCircle" fill="#fff" width={21} height={21} />
+          </TouchableOpacity> : null }
       </View>
     )
 
@@ -140,6 +145,7 @@ function SelectBox({
     arrowIconColor = Colors.primary,
     searchIconColor = Colors.primary,
     toggleIconColor = Colors.primary,
+    bottomBarColor ='#ddd',
     searchInputProps,
     multiSelectInputFieldProps,
     listOptionProps = {},
@@ -188,7 +194,7 @@ function SelectBox({
   const kContainerStyle = {
     flexDirection: 'row',
     width: '100%',
-    borderColor: '#ddd',
+    borderColor: bottomBarColor,
     borderBottomWidth: 1,
     paddingTop: 6,
     paddingRight: 20,


### PR DESCRIPTION
**Motivation** 😇

On one hand, I faced the problem of can't remove the border-bottom of the main container. On the other hand, i couldn't remove the cross icon of the items selected in the main container.

**Actions** 💻

To solve the points listed above I added two props to the component:
- Prop to change the bottom border of the main container, using as default the previous one.
- Prop of hiding the cross icon when multiple items are selected.

Final result i got: 
![Captura de pantalla 2021-08-10 a las 14 10 43](https://user-images.githubusercontent.com/36212752/128864567-7eddf492-d7a1-4aa7-b5bb-139617106d2e.png)

Thanks for your attention,

Bruno

