### PR TITLE
Hide dropdown icon to do not toggle & callback function to know if is editable or no

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ function SelectBox({
   multiListEmptyLabelStyle,
   listEmptyLabelStyle,
   selectedItemStyle,
+  editStatus,
   listEmptyText = 'No results found',
   ...props
 }) {
@@ -129,6 +130,7 @@ function SelectBox({
   }
   const {
     selectIcon,
+    noEditable,
     label,
     inputPlaceholder = 'Select',
     hideInputFilter,
@@ -221,9 +223,11 @@ function SelectBox({
               </TouchableOpacity>
             )}
           </View>
-          <TouchableOpacity onPress={onPressShowOptions()} hitSlop={hitSlop}>
-            {selectIcon ? selectIcon : <Icon name={showOptions ? 'upArrow' : 'downArrow'} fill={arrowIconColor} />}
-          </TouchableOpacity>
+          {noEditable ? null : 
+            <TouchableOpacity onPress={onPressShowOptions()} hitSlop={hitSlop}>
+              {selectIcon ? selectIcon : <Icon name={showOptions ? 'upArrow' : 'downArrow'} fill={arrowIconColor} />}
+            </TouchableOpacity>
+          }
         </View>
         {/* Options wrapper */}
         {showOptions && (
@@ -303,6 +307,7 @@ function SelectBox({
   }
 
   function onPressShowOptions() {
+    editStatus ? editStatus(showOptions) : null
     return () => setShowOptions(!showOptions)
   }
 }


### PR DESCRIPTION
**Motivation** 😇
The first problem I had was to can't remove the toggle icon when the user is not in edit mode. If in the custom component prop to toggle receive an empty container and the user press on that area the toggle gonna trigger. 

The second was to do not have a way to know if the options list is displaying or not.

**Actions**💻
To fix the first issue, I added a prop that allows to do not display anything.
To fix the second, I added a prop that calls a callback function to get the current status of the toggle (if the options lists are being displayed or not).

Thanks for your attention,

Bruno.