### PR TITLE
perf: SelectBox vital memoization (Icon, callbacks, row memos)

### DIFF
--- a/packages/multi-selectbox/__tests__/utils/options.test.ts
+++ b/packages/multi-selectbox/__tests__/utils/options.test.ts
@@ -1,4 +1,6 @@
 import {
+  buildOptionLabelById,
+  buildSelectedIdSet,
   filterOptions,
   isOptionSelected,
   normalizeOptions,
@@ -40,5 +42,21 @@ describe('options utils', () => {
   it('isOptionSelected matches by id', () => {
     expect(isOptionSelected([{ id: 'a', item: 'Alpha' }], sample[0]!)).toBe(true)
     expect(isOptionSelected([{ id: 'a', item: 'Alpha' }], sample[1]!)).toBe(false)
+  })
+
+  it('buildSelectedIdSet supports O(1) has()', () => {
+    const set = buildSelectedIdSet([
+      { id: 'a', item: 'Alpha' },
+      { id: 2, item: 'Two' },
+    ])
+    expect(set.has('a')).toBe(true)
+    expect(set.has(2)).toBe(true)
+    expect(set.has('missing')).toBe(false)
+  })
+
+  it('buildOptionLabelById maps ids to labels', () => {
+    const map = buildOptionLabelById(sample)
+    expect(map.get('a')).toBe('Alpha')
+    expect(map.get('b')).toBe('Beta')
   })
 })

--- a/packages/multi-selectbox/src/SelectBox.tsx
+++ b/packages/multi-selectbox/src/SelectBox.tsx
@@ -1,16 +1,21 @@
-import { memo, useMemo, useState, type ReactElement } from 'react'
+import { memo, useCallback, useMemo, useState, type ReactElement } from 'react'
 import { Text, View, type StyleProp, type TextStyle } from 'react-native'
 import Colors from './constants/Colors'
-import { SelectField } from './components/SelectBox/SelectField'
-import { OptionsPanel } from './components/SelectBox/OptionsPanel'
+import SelectField from './components/SelectBox/SelectField'
+import OptionsPanel from './components/SelectBox/OptionsPanel'
 import {
+  EMPTY_OBJECT,
   EMPTY_OPTIONS,
+  buildOptionLabelById,
+  buildSelectedIdSet,
   filterOptions,
   normalizeOptions,
   readSelectedItemText,
 } from './utils/options'
 import { TEST_IDS } from './testIDs'
-import type { SelectBoxProps, SelectOption } from './types'
+import type { OptionsListProps, SelectBoxProps, SelectOption } from './types'
+
+const EMPTY_ID_SET: ReadonlySet<string | number> = new Set()
 
 function SelectBox(props: SelectBoxProps): ReactElement {
   const {
@@ -38,7 +43,7 @@ function SelectBox(props: SelectBoxProps): ReactElement {
     toggleIconColor = Colors.primary,
     searchInputProps,
     multiSelectInputFieldProps,
-    listOptionProps = {},
+    listOptionProps,
   } = props
 
   const options = normalizeOptions(optionsProp)
@@ -58,6 +63,8 @@ function SelectBox(props: SelectBoxProps): ReactElement {
     ? (props as Extract<SelectBoxProps, { isMulti: true }>).onTapClose
     : undefined
 
+  const resolvedListOptionProps = (listOptionProps ?? EMPTY_OBJECT) as OptionsListProps
+
   const [inputValue, setInputValue] = useState('')
   const [showOptions, setShowOptions] = useState(false)
 
@@ -66,9 +73,16 @@ function SelectBox(props: SelectBoxProps): ReactElement {
     [inputValue, options],
   )
 
+  const selectedIdSet = useMemo(
+    () => (isMulti ? buildSelectedIdSet(selectedValues) : EMPTY_ID_SET),
+    [isMulti, selectedValues],
+  )
+
+  const optionLabelById = useMemo(() => buildOptionLabelById(options), [options])
+
   const selectedItemText = readSelectedItemText(value)
 
-  const toggleOptions = () => {
+  const toggleOptions = useCallback(() => {
     setShowOptions((open) => {
       const next = !open
       if (!next) {
@@ -76,17 +90,20 @@ function SelectBox(props: SelectBoxProps): ReactElement {
       }
       return next
     })
-  }
+  }, [])
 
-  const handleSelectOption = (item: SelectOption) => {
-    if (isMulti) {
-      onMultiSelect?.(item)
-      return
-    }
-    setShowOptions(false)
-    setInputValue('')
-    onChange?.(item)
-  }
+  const handleSelectOption = useCallback(
+    (item: SelectOption) => {
+      if (isMulti) {
+        onMultiSelect?.(item)
+        return
+      }
+      setShowOptions(false)
+      setInputValue('')
+      onChange?.(item)
+    },
+    [isMulti, onChange, onMultiSelect],
+  )
 
   const fieldLabelStyle: StyleProp<TextStyle> = [
     {
@@ -112,7 +129,7 @@ function SelectBox(props: SelectBoxProps): ReactElement {
         arrowIconColor={arrowIconColor}
         containerStyle={containerStyle}
         selectedItemStyle={selectedItemStyle}
-        options={options}
+        optionLabelById={optionLabelById}
         selectedValues={selectedValues}
         multiOptionContainerStyle={multiOptionContainerStyle}
         multiOptionsLabelStyle={multiOptionsLabelStyle}
@@ -124,7 +141,7 @@ function SelectBox(props: SelectBoxProps): ReactElement {
       {showOptions && (
         <OptionsPanel
           options={filteredSuggestions}
-          selectedValues={selectedValues}
+          selectedIdSet={selectedIdSet}
           isMulti={Boolean(isMulti)}
           inputValue={inputValue}
           onChangeInput={setInputValue}
@@ -139,7 +156,7 @@ function SelectBox(props: SelectBoxProps): ReactElement {
           optionsLabelStyle={optionsLabelStyle}
           optionContainerStyle={optionContainerStyle}
           listEmptyLabelStyle={listEmptyLabelStyle}
-          listOptionProps={listOptionProps}
+          listOptionProps={resolvedListOptionProps}
           onSelectOption={handleSelectOption}
         />
       )}

--- a/packages/multi-selectbox/src/components/Icon.tsx
+++ b/packages/multi-selectbox/src/components/Icon.tsx
@@ -1,5 +1,5 @@
 import { memo, type ReactElement } from 'react'
-import { View, type ViewProps } from 'react-native'
+import { View } from 'react-native'
 import Svg, { Path, G, Ellipse, Polygon, Circle, type SvgProps } from 'react-native-svg'
 
 export type IconName =
@@ -17,118 +17,124 @@ type GraphicDef = {
   width: number
   height: number
   viewBox: string
-  content: ReactElement
+  content: (fill: string) => ReactElement
+}
+
+const GRAPHICS: Record<IconName, GraphicDef> = {
+  downArrow: {
+    width: 12,
+    height: 9,
+    viewBox: '0 0 12 9',
+    content: (fill) => (
+      <G id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+        <Polygon id="down" fill={fill} points="5.625 9 11.25 0 0 0" />
+      </G>
+    ),
+  },
+  upArrow: {
+    width: 12,
+    height: 9,
+    viewBox: '0 0 12 9',
+    content: (fill) => (
+      <G id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+        <Polygon
+          id="up"
+          fill={fill}
+          transform="translate(5.625000, 4.500000) rotate(-180.000000) translate(-5.625000, -4.500000) "
+          points="5.625 9 11.25 0 0 0"
+        />
+      </G>
+    ),
+  },
+  deleteCircle: {
+    width: 22,
+    height: 22,
+    viewBox: '0 0 22 22',
+    content: (fill) => (
+      <G fill="none" fillRule="evenodd">
+        <Circle cx="10" cy="10" r="10" fill={fill} />
+        <Path stroke="#FFF" strokeWidth="2" d="M16.451 10.451H3.55" />
+      </G>
+    ),
+  },
+  searchBoxIcon: {
+    width: 18,
+    height: 16,
+    viewBox: '0 0 18 16',
+    content: (fill) => (
+      <G
+        fill="none"
+        fillRule="evenodd"
+        stroke={fill}
+        strokeWidth="1.2"
+        transform="translate(1.4 1.16)"
+      >
+        <Ellipse cx="5.921" cy="6.178" rx="5.921" ry="6.178" />
+        <Path d="M10.812 9.782L15.96 13.9" />
+      </G>
+    ),
+  },
+  addCircle: {
+    width: 22,
+    height: 22,
+    viewBox: '0 0 22 22',
+    content: (fill) => (
+      <G fill="none" fillRule="evenodd" stroke={fill} strokeWidth=".8" transform="translate(1 1)">
+        <Circle cx="10" cy="10" r="10" />
+        <Path d="M10 3.2v12.903M16.451 9.651H3.55" />
+      </G>
+    ),
+  },
+  closeCircle: {
+    width: 24,
+    height: 20,
+    viewBox: '0 0 23 23',
+    content: (fill) => (
+      <G id="mobile" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+        <G id="close" transform="translate(1.000000, 1.000000)" stroke={fill}>
+          <Circle id="Oval" cx="10.5" cy="10.5" r="10.5" />
+          <Path
+            d="M5,10.5 L16.8436214,10.5"
+            id="Path-2"
+            transform="translate(10.921811, 10.500000) rotate(-315.000000) translate(-10.921811, -10.500000) "
+          />
+          <Path
+            d="M5,10.5 L16.8436214,10.5"
+            id="Path-2-Copy"
+            transform="translate(10.921811, 10.500000) rotate(-585.000000) translate(-10.921811, -10.500000) "
+          />
+        </G>
+      </G>
+    ),
+  },
+}
+
+const DEFAULT_FILLS: Partial<Record<IconName, string>> = {
+  downArrow: '#4A90E2',
+  upArrow: '#4A90E2',
+  deleteCircle: '#E02020',
+  searchBoxIcon: '#0575E6',
+  addCircle: '#0575E6',
+  closeCircle: '#0575E6',
 }
 
 function Icon({ name, fill, width, height, viewBox, ...otherProps }: IconProps) {
-  const graphics: Record<IconName, GraphicDef> = {
-    downArrow: {
-      width: 12,
-      height: 9,
-      viewBox: '0 0 12 9',
-      content: (
-        <G id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-          <Polygon id="down" fill={fill || '#4A90E2'} points="5.625 9 11.25 0 0 0" />
-        </G>
-      ),
-    },
-    upArrow: {
-      width: 12,
-      height: 9,
-      viewBox: '0 0 12 9',
-      content: (
-        <G id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-          <Polygon
-            id="up"
-            fill={fill || '#4A90E2'}
-            transform="translate(5.625000, 4.500000) rotate(-180.000000) translate(-5.625000, -4.500000) "
-            points="5.625 9 11.25 0 0 0"
-          />
-        </G>
-      ),
-    },
-    deleteCircle: {
-      width: 22,
-      height: 22,
-      viewBox: '0 0 22 22',
-      content: (
-        <G fill="none" fillRule="evenodd">
-          <Circle cx="10" cy="10" r="10" fill={fill || '#E02020'} />
-          <Path stroke="#FFF" strokeWidth="2" d="M16.451 10.451H3.55" />
-        </G>
-      ),
-    },
-    searchBoxIcon: {
-      width: width || 18,
-      height: height || 16,
-      viewBox: '0 0 18 16',
-      content: (
-        <G
-          fill="none"
-          fillRule="evenodd"
-          stroke={fill || '#0575E6'}
-          strokeWidth="1.2"
-          transform="translate(1.4 1.16)"
-        >
-          <Ellipse cx="5.921" cy="6.178" rx="5.921" ry="6.178" />
-          <Path d="M10.812 9.782L15.96 13.9" />
-        </G>
-      ),
-    },
-    addCircle: {
-      width: 22,
-      height: 22,
-      viewBox: '0 0 22 22',
-      content: (
-        <G
-          fill="none"
-          fillRule="evenodd"
-          stroke={fill || '#0575E6'}
-          strokeWidth=".8"
-          transform="translate(1 1)"
-        >
-          <Circle cx="10" cy="10" r="10" />
-          <Path d="M10 3.2v12.903M16.451 9.651H3.55" />
-        </G>
-      ),
-    },
-    closeCircle: {
-      width: width || 24,
-      height: height || 20,
-      viewBox: '0 0 23 23',
-      content: (
-        <G id="mobile" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-          <G id="close" transform="translate(1.000000, 1.000000)" stroke={fill || '#0575E6'}>
-            <Circle id="Oval" cx="10.5" cy="10.5" r="10.5" />
-            <Path
-              d="M5,10.5 L16.8436214,10.5"
-              id="Path-2"
-              transform="translate(10.921811, 10.500000) rotate(-315.000000) translate(-10.921811, -10.500000) "
-            />
-            <Path
-              d="M5,10.5 L16.8436214,10.5"
-              id="Path-2-Copy"
-              transform="translate(10.921811, 10.500000) rotate(-585.000000) translate(-10.921811, -10.500000) "
-            />
-          </G>
-        </G>
-      ),
-    },
-  }
-
-  const graphic = graphics[name]
+  const graphic = GRAPHICS[name]
+  const resolvedFill = fill ?? DEFAULT_FILLS[name] ?? '#0575E6'
+  const resolvedWidth = width ?? graphic.width
+  const resolvedHeight = height ?? graphic.height
 
   return (
-    <View pointerEvents="none" {...({} as ViewProps)}>
+    <View pointerEvents="none">
       <Svg
-        width={width ?? graphic.width}
-        height={height ?? graphic.height}
+        width={resolvedWidth}
+        height={resolvedHeight}
         viewBox={viewBox ?? graphic.viewBox}
         x={0}
         y={0}
         {...otherProps}
       >
-        {graphic.content}
+        {graphic.content(resolvedFill)}
       </Svg>
     </View>
   )

--- a/packages/multi-selectbox/src/components/SelectBox/FilterInput.tsx
+++ b/packages/multi-selectbox/src/components/SelectBox/FilterInput.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import { memo, type ReactElement } from 'react'
 import {
   TextInput,
   StyleSheet,
@@ -21,7 +21,7 @@ export type FilterInputProps = {
   searchInputProps?: TextInputProps | undefined
 }
 
-export function FilterInput({
+function FilterInput({
   value,
   onChangeText,
   placeholder,
@@ -77,3 +77,5 @@ export function FilterInput({
     </View>
   )
 }
+
+export default memo(FilterInput)

--- a/packages/multi-selectbox/src/components/SelectBox/MultiChipsRow.tsx
+++ b/packages/multi-selectbox/src/components/SelectBox/MultiChipsRow.tsx
@@ -1,5 +1,4 @@
-import type { ReactElement } from 'react'
-import { find } from 'lodash'
+import { memo, type ReactElement } from 'react'
 import {
   ScrollView,
   Text,
@@ -17,7 +16,8 @@ import type { MultiSelectFieldProps, SelectOption } from '../../types'
 import { MultiEmptyPlaceholder } from './EmptyStates'
 
 export type MultiChipsRowProps = {
-  options: SelectOption[]
+  /** id → display label (from full options catalog). */
+  optionLabelById: ReadonlyMap<string | number, string>
   selectedValues: SelectOption[]
   inputPlaceholder: string
   multiOptionContainerStyle?: StyleProp<ViewStyle> | undefined
@@ -72,8 +72,8 @@ function Chip({
   )
 }
 
-export function MultiChipsRow({
-  options,
+function MultiChipsRow({
+  optionLabelById,
   selectedValues,
   inputPlaceholder,
   multiOptionContainerStyle,
@@ -110,8 +110,7 @@ export function MultiChipsRow({
       {...restMultiFieldProps}
     >
       {selectedValues.map((item) => {
-        const matched = find(options, (o) => o.id === item.id)
-        const chipLabel = matched?.item ?? item.item
+        const chipLabel = optionLabelById.get(item.id) ?? item.item
         return (
           <Chip
             key={String(item.id)}
@@ -126,3 +125,5 @@ export function MultiChipsRow({
     </ScrollView>
   )
 }
+
+export default memo(MultiChipsRow)

--- a/packages/multi-selectbox/src/components/SelectBox/OptionRow.tsx
+++ b/packages/multi-selectbox/src/components/SelectBox/OptionRow.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import { memo, type ReactElement } from 'react'
 import {
   Text,
   TouchableOpacity,
@@ -22,7 +22,7 @@ export type OptionRowProps = {
   onPress: (item: SelectOption) => void
 }
 
-export function OptionRow({
+function OptionRow({
   item,
   isMulti,
   checked = false,
@@ -83,3 +83,18 @@ export function OptionRow({
     </View>
   )
 }
+
+function optionRowPropsAreEqual(prev: OptionRowProps, next: OptionRowProps): boolean {
+  return (
+    prev.item.id === next.item.id &&
+    prev.item.item === next.item.item &&
+    prev.isMulti === next.isMulti &&
+    prev.checked === next.checked &&
+    prev.toggleIconColor === next.toggleIconColor &&
+    prev.optionsLabelStyle === next.optionsLabelStyle &&
+    prev.optionContainerStyle === next.optionContainerStyle &&
+    prev.onPress === next.onPress
+  )
+}
+
+export default memo(OptionRow, optionRowPropsAreEqual)

--- a/packages/multi-selectbox/src/components/SelectBox/OptionsPanel.tsx
+++ b/packages/multi-selectbox/src/components/SelectBox/OptionsPanel.tsx
@@ -1,17 +1,22 @@
-import type { ReactElement } from 'react'
-import { ScrollView, type StyleProp, type TextStyle, type ViewStyle } from 'react-native'
+import { memo, type ReactElement } from 'react'
+import {
+  ScrollView,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+  type TextInputProps,
+} from 'react-native'
 import { optionsPanelStyle } from '../../constants/layout'
-import { isOptionSelected } from '../../utils/options'
 import { TEST_IDS } from '../../testIDs'
 import type { OptionsListProps, SelectOption } from '../../types'
 import { OptionsListEmpty } from './EmptyStates'
-import { FilterInput } from './FilterInput'
-import { OptionRow } from './OptionRow'
-import type { TextInputProps } from 'react-native'
+import FilterInput from './FilterInput'
+import OptionRow from './OptionRow'
 
 export type OptionsPanelProps = {
   options: SelectOption[]
-  selectedValues: SelectOption[]
+  /** Precomputed selected ids for O(1) checked state (multi). */
+  selectedIdSet: ReadonlySet<string | number>
   isMulti: boolean
   inputValue: string
   onChangeInput: (text: string) => void
@@ -30,9 +35,9 @@ export type OptionsPanelProps = {
   onSelectOption: (item: SelectOption) => void
 }
 
-export function OptionsPanel({
+function OptionsPanel({
   options,
-  selectedValues,
+  selectedIdSet,
   isMulti,
   inputValue,
   onChangeInput,
@@ -47,7 +52,7 @@ export function OptionsPanel({
   optionsLabelStyle,
   optionContainerStyle,
   listEmptyLabelStyle,
-  listOptionProps = {},
+  listOptionProps,
   onSelectOption,
 }: OptionsPanelProps): ReactElement {
   const {
@@ -56,7 +61,7 @@ export function OptionsPanel({
     keyboardShouldPersistTaps = 'handled',
     nestedScrollEnabled = true,
     ...restListOptionProps
-  } = listOptionProps
+  } = listOptionProps ?? {}
 
   return (
     <ScrollView
@@ -86,7 +91,7 @@ export function OptionsPanel({
             key={String(item.id)}
             item={item}
             isMulti={isMulti}
-            checked={isMulti ? isOptionSelected(selectedValues, item) : false}
+            checked={isMulti ? selectedIdSet.has(item.id) : false}
             toggleIconColor={toggleIconColor}
             optionsLabelStyle={optionsLabelStyle}
             optionContainerStyle={optionContainerStyle}
@@ -97,3 +102,5 @@ export function OptionsPanel({
     </ScrollView>
   )
 }
+
+export default memo(OptionsPanel)

--- a/packages/multi-selectbox/src/components/SelectBox/SelectField.tsx
+++ b/packages/multi-selectbox/src/components/SelectBox/SelectField.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react'
+import { memo, type ReactElement, type ReactNode } from 'react'
 import { isEmpty } from 'lodash'
 import {
   Text,
@@ -13,7 +13,7 @@ import { hitSlop } from '../../constants/layout'
 import Icon from '../Icon'
 import { TEST_IDS } from '../../testIDs'
 import type { MultiSelectFieldProps, SelectOption } from '../../types'
-import { MultiChipsRow } from './MultiChipsRow'
+import MultiChipsRow from './MultiChipsRow'
 
 export type SelectFieldProps = {
   isMulti: boolean
@@ -25,7 +25,7 @@ export type SelectFieldProps = {
   arrowIconColor?: string | undefined
   containerStyle?: StyleProp<ViewStyle> | undefined
   selectedItemStyle?: StyleProp<TextStyle> | undefined
-  options: SelectOption[]
+  optionLabelById: ReadonlyMap<string | number, string>
   selectedValues: SelectOption[]
   multiOptionContainerStyle?: StyleProp<ViewStyle> | undefined
   multiOptionsLabelStyle?: StyleProp<TextStyle> | undefined
@@ -35,7 +35,7 @@ export type SelectFieldProps = {
   onToggleOpen: () => void
 }
 
-export function SelectField({
+function SelectField({
   isMulti,
   label,
   inputPlaceholder,
@@ -45,7 +45,7 @@ export function SelectField({
   arrowIconColor = Colors.primary,
   containerStyle,
   selectedItemStyle,
-  options,
+  optionLabelById,
   selectedValues,
   multiOptionContainerStyle,
   multiOptionsLabelStyle,
@@ -80,7 +80,7 @@ export function SelectField({
       <View style={{ paddingRight: 20, flexGrow: 1 }}>
         {isMulti ? (
           <MultiChipsRow
-            options={options}
+            optionLabelById={optionLabelById}
             selectedValues={selectedValues}
             inputPlaceholder={inputPlaceholder}
             multiOptionContainerStyle={multiOptionContainerStyle}
@@ -110,3 +110,5 @@ export function SelectField({
     </View>
   )
 }
+
+export default memo(SelectField)

--- a/packages/multi-selectbox/src/utils/options.ts
+++ b/packages/multi-selectbox/src/utils/options.ts
@@ -2,6 +2,9 @@ import type { SelectOption } from '../types'
 
 const EMPTY_OPTIONS: SelectOption[] = []
 
+/** Stable empty object for default prop objects (avoids breaking memo). */
+export const EMPTY_OBJECT = {} as const
+
 /** Coerce non-arrays (e.g. loading/API mistakes) to a safe empty list. */
 export function normalizeOptions(options: SelectOption[] | undefined): SelectOption[] {
   return Array.isArray(options) ? options : EMPTY_OPTIONS
@@ -26,6 +29,26 @@ export function filterOptions(options: SelectOption[], query: string): SelectOpt
 
 export function isOptionSelected(selected: SelectOption[], item: SelectOption): boolean {
   return selected.some((entry) => entry.id === item.id)
+}
+
+/** O(1) lookup for multi-select checked state across N rows. */
+export function buildSelectedIdSet(selected: SelectOption[]): ReadonlySet<string | number> {
+  const ids = new Set<string | number>()
+  for (const entry of selected) {
+    ids.add(entry.id)
+  }
+  return ids
+}
+
+/** Label lookup for chips when options catalog is large. */
+export function buildOptionLabelById(
+  options: SelectOption[],
+): ReadonlyMap<string | number, string> {
+  const map = new Map<string | number, string>()
+  for (const option of options) {
+    map.set(option.id, option.item)
+  }
+  return map
 }
 
 export { EMPTY_OPTIONS }


### PR DESCRIPTION
## Summary

Stacked on `chore/expo-monorepo-migration`. Implements the **vital memoization** pass from the package performance review—without changing public SelectBox API or behavior.

## Changes

| Area | What |
|------|------|
| **Icon** | Module-scope `GRAPHICS` factories parameterized by `fill` (no per-render SVG def rebuild) |
| **SelectBox** | `useCallback` for `toggleOptions` / `handleSelectOption`; `useMemo` for `filteredSuggestions`, **`selectedIdSet`**, **`optionLabelById`** |
| **Defaults** | `EMPTY_OBJECT` / `EMPTY_ID_SET` instead of inline `{}` / ad-hoc sets (memo-friendly) |
| **memo(...)** | `SelectField`, `OptionsPanel`, `OptionRow` (custom props equal), `FilterInput`, `MultiChipsRow` |
| **Multi checks** | O(1) `selectedIdSet.has(id)` per row instead of `.some` per row |
| **Chips** | Label via `Map` from options catalog (no `find` per chip) |

## Tests

- Existing SelectBox RNTL suites (14)
- Utils: `buildSelectedIdSet`, `buildOptionLabelById` (+ prior helpers) — **21** tests total

```bash
pnpm typecheck && pnpm test && pnpm lint && pnpm format:check
```

## Consumer note

Root `memo(SelectBox)` still rewards **stable** `options` / callbacks from the app. Inline `onChange={() => ...}` or `options={x.map(...)}` every render will bypass root memo (unchanged contract).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (21)
- [x] `pnpm lint` / `pnpm format:check`
- [ ] `pnpm example` smoke (optional)
