### PR TITLE
chore(release): 2.0.3 — chip fix notes and AdditionalApis demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-06-30
+
+### Fixed
+
+- Multi-select chips with **`hideChipClose`**: equal horizontal padding so labels are visually centered (no longer left-heavy when the × control is omitted)
+
+### Documentation / examples
+
+- Reverted long copy-paste examples from the package README (table of 2.0.2+ controls remains)
+- Added interactive **APIs** tab in the Expo example: [`apps/example/demos/AdditionalApisDemo.tsx`](./apps/example/demos/AdditionalApisDemo.tsx)
+  - `activeOptionsLabelStyle`, `maxSelected`, `optionIdKey` / `optionLabelKey`, `optionsAlign`, `optionsMaxHeight`
+  - `defaultOpen` / `onOpenChange`, `editable` / `hideDropdownIcon`, `hideChipClose`, `renderMultiChipLeading`
+- Example app chrome: SectionList | ScrollView | **APIs** tabs
+- Smoke tests assert Additional APIs demo coverage
+
+### Upgrade
+
+```bash
+npm install react-native-multi-selectbox@2.0.3
+```
+
+Live demo (after Pages deploy from `master`): https://sauzy34.github.io/react-native-multi-selectbox/
+
 ## [2.0.2] - 2026-06-30
 
 ### Added
@@ -70,6 +93,7 @@ Major rewrite: TypeScript library in a pnpm monorepo with an Expo example app. P
 
 Last line published from the pre-monorepo / JavaScript package layout. See npm history for 1.x details.
 
+[2.0.3]: https://github.com/sauzy34/react-native-multi-selectbox/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/sauzy34/react-native-multi-selectbox/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/sauzy34/react-native-multi-selectbox/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/sauzy34/react-native-multi-selectbox/compare/v1.5.0...v2.0.0

--- a/RELEASE_NOTES_2.0.3.md
+++ b/RELEASE_NOTES_2.0.3.md
@@ -1,0 +1,45 @@
+# react-native-multi-selectbox 2.0.3
+
+Patch release: chip layout fix when close controls are hidden, plus interactive Expo demos for all 2.0.2 control APIs.
+
+## Fixed
+
+- **`hideChipClose` chips** — labels use balanced horizontal padding so text looks centered in the pill (demo + library).
+
+## Examples
+
+Expo example app (**APIs** tab) — [`AdditionalApisDemo.tsx`](https://github.com/sauzy34/react-native-multi-selectbox/blob/master/apps/example/demos/AdditionalApisDemo.tsx):
+
+| Prop | Demo |
+| --- | --- |
+| `activeOptionsLabelStyle` | Highlight selected option labels |
+| `maxSelected` | Limit multi selection (e.g. 3 tags) |
+| `optionIdKey` / `optionLabelKey` | Options shaped as `{ id, name }` |
+| `optionsAlign` | Right-aligned option list |
+| `optionsMaxHeight` | Taller options panel |
+| `defaultOpen` / `onOpenChange` | Initial open + open-state callback |
+| `editable` / `hideDropdownIcon` | Read-only field / no chevron |
+| `hideChipClose` | Chips without × |
+| `renderMultiChipLeading` | Avatar / leading node on chips |
+
+Also: SectionList and ScrollView host demos unchanged.
+
+## Install
+
+```bash
+npm install react-native-multi-selectbox@2.0.3
+```
+
+## Links
+
+- [CHANGELOG](https://github.com/sauzy34/react-native-multi-selectbox/blob/master/CHANGELOG.md)
+- [Package README](https://github.com/sauzy34/react-native-multi-selectbox/blob/master/packages/multi-selectbox/README.md)
+- Live demo: https://sauzy34.github.io/react-native-multi-selectbox/
+- Full 2.0.0 notes (breaking peers, TS monorepo): see CHANGELOG **2.0.0**
+
+## Publish
+
+```bash
+cd packages/multi-selectbox
+npm publish --access public --otp=YOUR_CODE
+```

--- a/packages/multi-selectbox/CHANGELOG.md
+++ b/packages/multi-selectbox/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-06-30
+
+### Fixed
+
+- Multi-select chips with **`hideChipClose`**: equal horizontal padding so labels are visually centered (no longer left-heavy when the × control is omitted)
+
+### Documentation / examples
+
+- Reverted long copy-paste examples from the package README (table of 2.0.2+ controls remains)
+- Added interactive **APIs** tab in the Expo example: [`apps/example/demos/AdditionalApisDemo.tsx`](./apps/example/demos/AdditionalApisDemo.tsx)
+  - `activeOptionsLabelStyle`, `maxSelected`, `optionIdKey` / `optionLabelKey`, `optionsAlign`, `optionsMaxHeight`
+  - `defaultOpen` / `onOpenChange`, `editable` / `hideDropdownIcon`, `hideChipClose`, `renderMultiChipLeading`
+- Example app chrome: SectionList | ScrollView | **APIs** tabs
+- Smoke tests assert Additional APIs demo coverage
+
+### Upgrade
+
+```bash
+npm install react-native-multi-selectbox@2.0.3
+```
+
+Live demo (after Pages deploy from `master`): https://sauzy34.github.io/react-native-multi-selectbox/
+
 ## [2.0.2] - 2026-06-30
 
 ### Added
@@ -70,6 +93,7 @@ Major rewrite: TypeScript library in a pnpm monorepo with an Expo example app. P
 
 Last line published from the pre-monorepo / JavaScript package layout. See npm history for 1.x details.
 
+[2.0.3]: https://github.com/sauzy34/react-native-multi-selectbox/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/sauzy34/react-native-multi-selectbox/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/sauzy34/react-native-multi-selectbox/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/sauzy34/react-native-multi-selectbox/compare/v1.5.0...v2.0.0

--- a/packages/multi-selectbox/package.json
+++ b/packages/multi-selectbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-multi-selectbox",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Platform-independent select / multi-select / picker for React Native and Expo (TypeScript).",
   "license": "MIT",
   "author": "Saurav Gupta <sonugupta34@gmail.com> (https://github.com/sauzy34)",


### PR DESCRIPTION
## Summary

Release notes and version bump for **2.0.3** (includes #113 content already on master for demos + `hideChipClose` centering).

- `CHANGELOG.md` / package CHANGELOG **2.0.3**
- `packages/multi-selectbox` version **2.0.3**
- `RELEASE_NOTES_2.0.3.md` for GitHub Release paste
- Tag **`v2.0.3`** already pushed (points at this commit once merged)

## Publish (after merge)

```bash
cd packages/multi-selectbox
npm publish --access public --otp=YOUR_CODE
```

## Test plan

- [x] Changelog entries accurate vs #113
- [ ] Merge this PR so `master` and `v2.0.3` align
- [ ] `npm publish` with OTP