### PR TITLE
fix: publish from packages/multi-selectbox (not private monorepo root)

### DIFF
--- a/RELEASE_NOTES_2.0.3.md
+++ b/RELEASE_NOTES_2.0.3.md
@@ -10,17 +10,17 @@ Patch release: chip layout fix when close controls are hidden, plus interactive 
 
 Expo example app (**APIs** tab) — [`AdditionalApisDemo.tsx`](https://github.com/sauzy34/react-native-multi-selectbox/blob/master/apps/example/demos/AdditionalApisDemo.tsx):
 
-| Prop | Demo |
-| --- | --- |
-| `activeOptionsLabelStyle` | Highlight selected option labels |
-| `maxSelected` | Limit multi selection (e.g. 3 tags) |
-| `optionIdKey` / `optionLabelKey` | Options shaped as `{ id, name }` |
-| `optionsAlign` | Right-aligned option list |
-| `optionsMaxHeight` | Taller options panel |
-| `defaultOpen` / `onOpenChange` | Initial open + open-state callback |
-| `editable` / `hideDropdownIcon` | Read-only field / no chevron |
-| `hideChipClose` | Chips without × |
-| `renderMultiChipLeading` | Avatar / leading node on chips |
+| Prop                             | Demo                                |
+| -------------------------------- | ----------------------------------- |
+| `activeOptionsLabelStyle`        | Highlight selected option labels    |
+| `maxSelected`                    | Limit multi selection (e.g. 3 tags) |
+| `optionIdKey` / `optionLabelKey` | Options shaped as `{ id, name }`    |
+| `optionsAlign`                   | Right-aligned option list           |
+| `optionsMaxHeight`               | Taller options panel                |
+| `defaultOpen` / `onOpenChange`   | Initial open + open-state callback  |
+| `editable` / `hideDropdownIcon`  | Read-only field / no chevron        |
+| `hideChipClose`                  | Chips without ×                     |
+| `renderMultiChipLeading`         | Avatar / leading node on chips      |
 
 Also: SectionList and ScrollView host demos unchanged.
 
@@ -39,7 +39,10 @@ npm install react-native-multi-selectbox@2.0.3
 
 ## Publish
 
-```bash
-cd packages/multi-selectbox
-npm publish --access public --otp=YOUR_CODE
-```
+> **Publish from the library package only.** The repo root `package.json` is the **monorepo** (`private: true`) and cannot be published. Use:
+>
+> ```bash
+> cd packages/multi-selectbox && npm publish --access public --otp=YOUR_CODE
+> # or from repo root:
+> pnpm publish:lib --otp=YOUR_CODE
+> ```

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "build": "pnpm -r --if-present run build",
-    "clean": "pnpm -r --if-present run clean && rm -rf node_modules"
+    "clean": "pnpm -r --if-present run clean && rm -rf node_modules",
+    "publish:lib": "pnpm --filter react-native-multi-selectbox publish --access public",
+    "pack:lib": "pnpm --filter react-native-multi-selectbox exec npm pack"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/packages/multi-selectbox/README.md
+++ b/packages/multi-selectbox/README.md
@@ -64,6 +64,8 @@ pnpm add react-native-multi-selectbox
 
 No extra native modules. Works with Expo managed workflow and bare RN.
 
+> **Maintainers:** publish this package from `packages/multi-selectbox` (or `pnpm publish:lib` at the repo root). Do not run `npm publish` at the monorepo root — that package is `private: true`.
+
 ---
 
 ## Quick start

--- a/packages/multi-selectbox/package.json
+++ b/packages/multi-selectbox/package.json
@@ -66,5 +66,6 @@
     "react-native": "0.85.3",
     "react-test-renderer": "19.2.3",
     "typescript": "~5.9.2"
-  }
+  },
+  "private": false
 }


### PR DESCRIPTION
## Summary

`npm publish` at the **repo root** fails because the monorepo `package.json` is intentionally **`private: true`** (`react-native-multi-selectbox-monorepo`).

The **library** at `packages/multi-selectbox` was never private; this PR:

- Sets **`"private": false`** explicitly on the publishable package
- Adds root scripts **`pnpm publish:lib`** / **`pnpm pack:lib`**
- Documents the correct publish path in README / package README / release notes

## Publish now (even before this merges)

```bash
cd packages/multi-selectbox
npm publish --access public --otp=YOUR_CODE
```

## Test plan

- [x] Confirm root has `private: true`, library has `private: false`
- [ ] `cd packages/multi-selectbox && npm publish --dry-run`