### PR TITLE
ci: create GitHub Release on publish via tag workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+# Create or update a GitHub Release when a v* tag is pushed.
+# Triggered automatically by `pnpm publish:lib` (tags + pushes vX.Y.Z after npm publish).
+#
+# Manual re-run / backfill:
+#   gh workflow run Release -f tag=v2.0.3
+#   or: git push origin v2.0.3 (if tag already points at the right commit)
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to publish/update as a GitHub Release (e.g. v2.0.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          case "$TAG" in
+            v*) ;;
+            *) TAG="v${TAG}" ;;
+          esac
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Using tag=${TAG} version=${VERSION}"
+
+      - uses: actions/checkout@v7
+        with:
+          # Need full history / the tag commit for notes extraction.
+          fetch-depth: 0
+          ref: ${{ steps.meta.outputs.tag }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        run: |
+          node scripts/extract-changelog.mjs "${{ steps.meta.outputs.version }}" > release-notes.md
+          echo "----- release notes -----"
+          cat release-notes.md
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.meta.outputs.tag }}"
+          VERSION="${{ steps.meta.outputs.version }}"
+          TITLE="${VERSION}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Updating existing release $TAG"
+            gh release edit "$TAG" \
+              --title "$TITLE" \
+              --notes-file release-notes.md \
+              --latest
+          else
+            echo "Creating release $TAG"
+            gh release create "$TAG" \
+              --title "$TITLE" \
+              --notes-file release-notes.md \
+              --latest \
+              --verify-tag
+          fi
+
+          echo "Release URL: $(gh release view "$TAG" --json url -q .url)"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ Demo hosts: [`apps/example/demos/SectionListHostDemo.tsx`](./apps/example/demos/
 
 CI deploys the web demo to GitHub Pages on push to `master` / `main` ([workflow](./.github/workflows/ci.yml)).
 
+### Publish (npm + GitHub Release)
+
+1. Bump `packages/multi-selectbox/package.json` `version` and add notes under that version in [`CHANGELOG.md`](./CHANGELOG.md) (keep the package copy in sync).
+2. Commit and push the version bump to `master`.
+3. From the monorepo root:
+
+```bash
+pnpm publish:lib
+# with npm OTP:
+pnpm publish:lib -- --otp=123456
+```
+
+`publish:lib` publishes to npm, creates/pushes tag `vX.Y.Z`, and the [Release](./.github/workflows/release.yml) workflow creates or updates the matching GitHub Release from the CHANGELOG section.
+
+- npm only (no tag / no GH release): `pnpm publish:lib -- --no-tag`
+- dry-run: `pnpm publish:lib -- --dry-run`
+- re-run release for an existing tag: **Actions → Release → Run workflow** and enter `vX.Y.Z`
+
 ---
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "format:check": "prettier --check .",
     "build": "pnpm -r --if-present run build",
     "clean": "pnpm -r --if-present run clean && rm -rf node_modules",
-    "publish:lib": "pnpm --filter react-native-multi-selectbox publish --access public",
+    "publish:lib": "node scripts/publish-lib.mjs",
     "pack:lib": "pnpm --filter react-native-multi-selectbox exec npm pack"
   },
   "devDependencies": {

--- a/scripts/extract-changelog.mjs
+++ b/scripts/extract-changelog.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Print the CHANGELOG.md body for a given semver (with or without leading "v").
+ * Usage: node scripts/extract-changelog.mjs 2.0.3
+ *        node scripts/extract-changelog.mjs v2.0.3
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const versionArg = process.argv[2]
+
+if (!versionArg) {
+  console.error('Usage: node scripts/extract-changelog.mjs <version>')
+  process.exit(1)
+}
+
+const version = versionArg.replace(/^v/i, '')
+const candidates = [
+  path.join(root, 'CHANGELOG.md'),
+  path.join(root, 'packages/multi-selectbox/CHANGELOG.md'),
+]
+
+const changelogPath = candidates.find((p) => fs.existsSync(p))
+if (!changelogPath) {
+  console.log(`## ${version}\n\nPublished \`react-native-multi-selectbox@${version}\`.\n`)
+  process.exit(0)
+}
+
+const text = fs.readFileSync(changelogPath, 'utf8')
+const escaped = version.replace(/\./g, '\\.')
+// Keep a Changelog: ## [2.0.3] - 2026-06-30
+const sectionRe = new RegExp(`## \\[${escaped}\\][^\\n]*\\n([\\s\\S]*?)(?=\\n## \\[|\\n\\[\\d|$)`)
+const match = text.match(sectionRe)
+
+if (!match) {
+  console.log(
+    `## ${version}\n\nPublished \`react-native-multi-selectbox@${version}\`.\n\nSee [CHANGELOG.md](https://github.com/sauzy34/react-native-multi-selectbox/blob/master/CHANGELOG.md) for details.\n`,
+  )
+  process.exit(0)
+}
+
+const body = match[1].trim()
+const install = `### Install
+
+\`\`\`bash
+npm install react-native-multi-selectbox@${version}
+\`\`\`
+`
+
+const hasInstall = /npm install react-native-multi-selectbox@/.test(body)
+console.log(hasInstall ? `${body}\n` : `${body}\n\n${install}\n`)

--- a/scripts/publish-lib.mjs
+++ b/scripts/publish-lib.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Publish react-native-multi-selectbox to npm, then push a v* git tag so the
+ * "Release" GitHub Actions workflow can create/update the GitHub Release.
+ *
+ * Usage (from monorepo root):
+ *   pnpm publish:lib
+ *   pnpm publish:lib -- --otp=123456
+ *   pnpm publish:lib -- --dry-run
+ *   pnpm publish:lib -- --no-tag          # npm only, skip git tag / CI release
+ *
+ * Env:
+ *   SKIP_GITHUB_RELEASE=1  same as --no-tag
+ */
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const pkgPath = path.join(root, 'packages/multi-selectbox/package.json')
+
+const rawArgs = process.argv.slice(2)
+const noTag = rawArgs.includes('--no-tag') || process.env.SKIP_GITHUB_RELEASE === '1'
+const publishArgs = rawArgs.filter((a) => a !== '--no-tag')
+
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+const version = pkg.version
+const tag = `v${version}`
+const dryRun = publishArgs.some((a) => a === '--dry-run' || a.startsWith('--dry-run='))
+
+function run(cmd, args, opts = {}) {
+  const result = spawnSync(cmd, args, {
+    cwd: root,
+    stdio: 'inherit',
+    shell: false,
+    ...opts,
+  })
+  if (result.error) {
+    throw result.error
+  }
+  return result.status ?? 1
+}
+
+function runCapture(cmd, args) {
+  return spawnSync(cmd, args, {
+    cwd: root,
+    encoding: 'utf8',
+    shell: false,
+  })
+}
+
+console.log(`\n📦 Publishing react-native-multi-selectbox@${version}…\n`)
+
+const publishStatus = run('pnpm', [
+  '--filter',
+  'react-native-multi-selectbox',
+  'publish',
+  '--access',
+  'public',
+  ...publishArgs,
+])
+if (publishStatus !== 0) {
+  process.exit(publishStatus)
+}
+
+if (noTag || dryRun) {
+  if (dryRun) {
+    console.log('\nDry run: skipping git tag and GitHub Release workflow.')
+  } else {
+    console.log('\n--no-tag / SKIP_GITHUB_RELEASE: skipping git tag.')
+  }
+  process.exit(0)
+}
+
+const tagExists = runCapture('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`])
+if (tagExists.status === 0) {
+  console.log(
+    `\nTag ${tag} already exists locally; will push to update remote + re-run Release workflow.`,
+  )
+} else {
+  console.log(`\n🏷  Creating annotated tag ${tag}…`)
+  const tagStatus = run('git', ['tag', '-a', tag, '-m', `Release ${tag}`])
+  if (tagStatus !== 0) {
+    process.exit(tagStatus)
+  }
+}
+
+console.log(`\n⬆  Pushing ${tag} to origin (triggers Release workflow)…`)
+const pushStatus = run('git', ['push', 'origin', tag])
+if (pushStatus !== 0) {
+  console.error(`
+Published to npm, but failed to push tag ${tag}.
+Create the GitHub Release by pushing the tag:
+
+  git push origin ${tag}
+`)
+  process.exit(pushStatus)
+}
+
+console.log(`
+✅ npm publish complete and ${tag} pushed.
+   GitHub Actions workflow "Release" will create or update:
+   https://github.com/sauzy34/react-native-multi-selectbox/releases/tag/${tag}
+`)


### PR DESCRIPTION
## Summary
Automates GitHub Releases from the existing publish path so the Releases page stays in sync with npm (avoids the 1.5.0-only gap we just fixed by hand).

### Flow
1. Bump version + `CHANGELOG.md` on `master`
2. Run `pnpm publish:lib` (optionally `-- --otp=…`)
3. Script publishes to npm, creates/pushes tag `vX.Y.Z`
4. New **Release** workflow creates **or updates** the GitHub Release for that tag, using the matching `CHANGELOG.md` section as notes

### Changes
- `.github/workflows/release.yml` — on `push` of `v*` tags (and `workflow_dispatch` for re-runs)
- `scripts/publish-lib.mjs` — used by `pnpm publish:lib`
- `scripts/extract-changelog.mjs` — notes extraction for CI
- Root `package.json` + README publish docs

### Options
| Command | Behavior |
|---|---|
| `pnpm publish:lib` | npm publish + tag push → GH Release |
| `pnpm publish:lib -- --otp=123456` | same with npm OTP |
| `pnpm publish:lib -- --no-tag` | npm only |
| `pnpm publish:lib -- --dry-run` | dry-run; no tag |
| Actions → Release → Run workflow | re-create/update notes for an existing tag |

### Test plan
- [ ] CI quality green on this PR
- [ ] After merge, optional smoke: `node scripts/extract-changelog.mjs 2.0.3` locally
- [ ] Next real publish: confirm Actions **Release** run and https://github.com/sauzy34/react-native-multi-selectbox/releases shows the new version as latest