### PR TITLE
docs: slim root README and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+Thanks for helping improve **react-native-multi-selectbox**.
+
+## Setup
+
+Requires **Node 20+** and **pnpm 10+**.
+
+```bash
+pnpm install
+```
+
+## Repo layout
+
+```text
+apps/example/                 # Expo demo (web + native)
+packages/multi-selectbox/     # Publishable library (npm: react-native-multi-selectbox)
+docs/MIGRATION.md             # 1.x → 2.0 migration notes
+.github/workflows/            # CI and Pages deploy
+```
+
+## Develop
+
+```bash
+pnpm example              # Expo start (offline by default) — press i / a / w
+pnpm example:web          # browser via react-native-web
+pnpm example:export:web   # static export → apps/example/dist
+pnpm typecheck
+pnpm test                 # Jest (library) + example smoke
+pnpm lint
+pnpm format
+pnpm --filter react-native-multi-selectbox build
+```
+
+| Script                       | Purpose                             |
+| ---------------------------- | ----------------------------------- |
+| `pnpm example`               | Start Expo example (offline)        |
+| `pnpm example:web`           | Start Expo web demo                 |
+| `pnpm example:export:web`    | Static `expo export --platform web` |
+| `pnpm typecheck`             | `tsc` in all packages               |
+| `pnpm test` / `pnpm test:ci` | Library Jest + example host smoke   |
+| `pnpm lint` / `pnpm format`  | ESLint / Prettier                   |
+
+Demo sources: [`apps/example/demos/`](./apps/example/demos/) · app chrome: [`apps/example/App.tsx`](./apps/example/App.tsx).
+
+CI runs quality checks and deploys the web demo to GitHub Pages on push to `master` / `main`.
+
+## Guidelines
+
+1. Use **pnpm** from the repo root.
+2. Library code lives in [`packages/multi-selectbox`](./packages/multi-selectbox). Exercise changes with `pnpm example` and `pnpm test`.
+3. Public API / consumer docs: update [`packages/multi-selectbox/README.md`](./packages/multi-selectbox/README.md).
+4. Keep Prettier and ESLint clean (`pnpm format` / `pnpm lint`).
+5. User-facing changes: add a section under the next version in [CHANGELOG.md](./CHANGELOG.md) (keep the copy under the package in sync for npm).
+
+## Publish (maintainers)
+
+1. Bump `version` in `packages/multi-selectbox/package.json` and update [CHANGELOG.md](./CHANGELOG.md).
+2. Commit and push to `master`.
+3. From the monorepo root:
+
+```bash
+pnpm publish:lib
+# with npm OTP if required:
+pnpm publish:lib -- --otp=123456
+```
+
+Publish only from the library package (the repo root is a private monorepo workspace).
+
+## Pull requests
+
+Open PRs against `master`. Describe the problem, the approach, and how you verified it (tests / example app).
+
+Issues and PRs: [github.com/sauzy34/react-native-multi-selectbox](https://github.com/sauzy34/react-native-multi-selectbox).

--- a/README.md
+++ b/README.md
@@ -7,34 +7,9 @@
 
 Cross-platform **select** / **multi-select** / **picker** for **React Native** and **Expo**.
 
-### Live demo
+**[Live demo](https://sauzy34.github.io/react-native-multi-selectbox/)**
 
-**[sauzy34.github.io/react-native-multi-selectbox](https://sauzy34.github.io/react-native-multi-selectbox/)**
-
----
-
-## Documentation (where to edit what)
-
-This repo has **two README files on purpose**. They serve different audiences — do **not** duplicate long API docs in both.
-
-| File                                                                             | Audience                                                             | Maintain                                                                  |
-| -------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **[`packages/multi-selectbox/README.md`](./packages/multi-selectbox/README.md)** | **npm + library consumers** (install, examples, props, types, hosts) | **Source of truth for the public API** — edit this when usage/docs change |
-| **This file (root)**                                                             | **GitHub / contributors** (monorepo map, scripts, contributing)      | Keep **short** — link to the package README for usage                     |
-
-**Do not** copy-paste the same examples into both files. If something drifts, update the package README only, then ensure this hub still links to it.
-
-Other approaches teams use (and why we don’t for now):
-
-- **Symlink root → package** — GitHub root would be 100% npm docs (fine for tiny repos; loses a clear contributor hub).
-- **Symlink package → root** — npm would ship monorepo/`pnpm example` noise (bad for consumers).
-- **Generate both from fragments** — best at larger scale (`docs/*.md` + a small script); overkill until you have many packages.
-
-Optional later: a `scripts/sync-readme.mjs` is unnecessary if you keep the split above.
-
----
-
-## Install (consumers)
+## Install
 
 ```bash
 npm install react-native-multi-selectbox
@@ -42,66 +17,16 @@ npm install react-native-multi-selectbox
 
 Peers: `react` ≥ 18, `react-native` ≥ 0.73.
 
-**Full guide:** [packages/multi-selectbox/README.md](./packages/multi-selectbox/README.md) — quick start, single/multi examples, scrolling hosts, props, types.
+## Docs
 
-**Changelog / 1.x → 2.0:** [CHANGELOG.md](./CHANGELOG.md) · layout notes: [docs/MIGRATION.md](./docs/MIGRATION.md)
-
----
-
-## Monorepo layout
-
-```text
-apps/example/                 # Expo SDK 56 demo (web + native)
-packages/multi-selectbox/     # Publishable library (npm name: react-native-multi-selectbox)
-docs/MIGRATION.md             # Migration plan & phase log
-.github/workflows/ci.yml      # quality + GitHub Pages deploy
-```
-
----
-
-## Develop
-
-Requires **Node 20+** and **pnpm 10+**.
-
-```bash
-pnpm install
-pnpm example              # Expo start (offline by default) — press i / a / w
-pnpm example:web          # browser via react-native-web
-pnpm example:export:web   # static export → apps/example/dist (Pages)
-pnpm typecheck
-pnpm test                 # Jest (library) + example smoke
-pnpm lint
-pnpm format
-pnpm --filter react-native-multi-selectbox build   # emit dist/ for publish
-```
-
-| Script                       | Purpose                             |
-| ---------------------------- | ----------------------------------- |
-| `pnpm example`               | Start Expo example (offline)        |
-| `pnpm example:web`           | Start Expo web demo                 |
-| `pnpm example:export:web`    | Static `expo export --platform web` |
-| `pnpm typecheck`             | `tsc` in all packages               |
-| `pnpm test` / `pnpm test:ci` | Library Jest + example host smoke   |
-| `pnpm lint` / `pnpm format`  | ESLint / Prettier                   |
-
-Demo hosts: [`apps/example/demos/SectionListHostDemo.tsx`](./apps/example/demos/SectionListHostDemo.tsx), [`ScrollViewHostDemo.tsx`](./apps/example/demos/ScrollViewHostDemo.tsx) · app chrome: [`apps/example/App.tsx`](./apps/example/App.tsx).
-
-CI deploys the web demo to GitHub Pages on push to `master` / `main` ([workflow](./.github/workflows/ci.yml)).
-
----
-
-## Contributing
-
-1. Use **pnpm** from the repo root.
-2. Library changes go in [`packages/multi-selectbox`](./packages/multi-selectbox); exercise with `pnpm example` / `pnpm test`.
-3. Update **consumer docs** in [`packages/multi-selectbox/README.md`](./packages/multi-selectbox/README.md) when the public API or recommended usage changes; update this root README only for monorepo/dev concerns.
-4. Keep Prettier/ESLint clean (`pnpm format` / `pnpm lint`).
-5. Release notes go in [CHANGELOG.md](./CHANGELOG.md) (mirrored under the package for npm).
-
-PRs and issues: [github.com/sauzy34/react-native-multi-selectbox](https://github.com/sauzy34/react-native-multi-selectbox).
-
----
+- **Usage, props & examples** → [packages/multi-selectbox/README.md](./packages/multi-selectbox/README.md)
+- **Changelog** → [CHANGELOG.md](./CHANGELOG.md)
+- **1.x → 2.0 migration** → [docs/MIGRATION.md](./docs/MIGRATION.md)
 
 ## License
 
 [MIT](./LICENSE) © [Saurav Gupta](https://github.com/sauzy34)
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/packages/multi-selectbox/README.md
+++ b/packages/multi-selectbox/README.md
@@ -6,8 +6,7 @@
 
 Cross-platform **select** / **multi-select** / **picker** for **React Native** and **Expo** (iOS, Android, web). Shared UI and a TypeScript-first API.
 
-> **This file is the consumer documentation source of truth** (npm + GitHub).  
-> Monorepo layout / contributor commands live in the [repository root README](../../README.md).
+> **Consumer docs** (install, API, examples). For monorepo development, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ### Live demo
 


### PR DESCRIPTION
## Summary
- **Root README** is minimal for visitors: badges, one-liner, live demo, install, doc links, license.
- Removed the “Documentation (where to edit what)” meta section and monorepo/dev noise from the landing page.
- **New [CONTRIBUTING.md](./CONTRIBUTING.md)** holds setup, layout, develop scripts, guidelines, and publish notes — surfaces under GitHub’s **Contributing** tab.
- Package README callout now points at `CONTRIBUTING.md` instead of the root README for monorepo work.

## Root README structure (after)
1. Badges + pitch
2. Live demo
3. Install
4. Docs links (usage / changelog / migration)
5. License
6. Link to contributing

## Test plan
- [ ] Skim root README on GitHub — no contributor-meta about dual READMEs
- [ ] Open **Contributing** tab / `CONTRIBUTING.md` — develop & PR guidance present
- [ ] Package README still the consumer entry for API/examples